### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,6 +7,11 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: write
+  security-events: write
+
 env:
   NODE_VERSION: '18'
   PNPM_VERSION: '8'


### PR DESCRIPTION
Potential fix for [https://github.com/FearMelts/BrightWell-Website/security/code-scanning/5](https://github.com/FearMelts/BrightWell-Website/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the tasks performed in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository's code.
- `actions: write` for uploading artifacts and SARIF files.
- `security-events: write` for uploading security scan results.

The `permissions` block will be added at the root level to apply to all jobs in the workflow. If any job requires additional or fewer permissions, a specific `permissions` block can be added to that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
